### PR TITLE
Make `clone` abstract again

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -24,47 +24,91 @@ api.common.copy = (
   return result;
 */
 
-api.common.clone = (
-  // Clone dataset (clone objects to new array)
-  ds
-) => cloneArray(ds);
+api.common.clone = (obj) => {
+  if (typeof(obj) !== 'object' || obj === null) return obj;
+  return Array.isArray(obj) ? cloneArr(obj) : cloneObj(obj);
+};
 
-function cloneObject(obj) {
-  const result = {};
-  const keys = Object.keys(obj);
-  const len = keys.length;
-  let i, key, val, type;
-  for (i = 0; i < len; i++) {
-    key = keys[i];
-    val = obj[key];
-    type = typeof(val);
-    if (type === 'object') {
-      result[key] = (
-        Array.isArray(val) ? cloneArray(val) : cloneObject(val)
-      );
+function cloneArr(arr) {
+  const size = arr.length;
+  const array = new Array(size);
+  let i, val;
+  for (i = 0; i < size; i++) {
+    val = arr[i];
+    if (typeof(val) !== 'object' || val === null) {
+      array[i] = val;
+    } else if (Array.isArray(val)) {
+      array[i] = cloneArr(val);
     } else {
-      result[key] = val;
+      array[i] = cloneObj(val);
     }
   }
-  return result;
+  return array;
 }
 
-function cloneArray(arr) {
-  const result = [];
-  const len = arr.length;
-  let i, val, type;
-  for (i = 0; i < len; i++) {
-    val = arr[i];
-    type = typeof(val);
-    if (type === 'object') {
-      result.push(
-        Array.isArray(val) ? cloneArray(val) : cloneObject(val)
-      );
+function cloneObj(obj) {
+  const clone = {};
+  const keys = Object.keys(obj);
+  const size = keys.length;
+  let i, val;
+  for (i = 0; i < size; i++) {
+    val = obj[keys[i]];
+    if (typeof(val) !== 'object' || val === null) {
+      clone[keys[i]] = val;
+    } else if (Array.isArray(val)) {
+      clone[keys[i]] = cloneArr(val);
     } else {
-      result.push(val);
+      clone[keys[i]] = cloneObj(val);
     }
   }
-  return result;
+  return clone;
+}
+
+api.common.duplucate = (obj) => {
+  if (typeof(obj) !== 'object' || obj === null) return obj;
+  const refs = new Map();
+  return Array.isArray(obj) ? duplicateArr(obj, refs) : duplicateObj(obj, refs);
+};
+
+function duplicateArr(arr, references) {
+  const size = arr.length;
+  const array = new Array(size);
+  references.set(arr, array);
+  let i, val;
+  for (i = 0; i < size; i++) {
+    val = arr[i];
+    if (references.has(val)) {
+      array[i] = references.get(val);
+    } else  if (typeof(val) !== 'object' || val === null) {
+      array[i] = val;
+    } else if (Array.isArray(val)) {
+      array[i] = duplicateArr(val, references);
+    } else {
+      array[i] = duplicateObj(val, references);
+    }
+  }
+  return array;
+}
+
+function duplicateObj(obj, references) {
+  const clone = obj.constructor ? new obj.constructor() : Object.create(null);
+  references.set(obj, clone);
+  const keys = Object.keys(obj);
+  const size = keys.length;
+  let i, val;
+  for (i = 0; i < size; i++) {
+    val = obj[keys[i]];
+    if (references.has(val)) {
+      clone[keys[i]] = references.get(val);
+    } else if (typeof(val) !== 'object' || val === null) {
+      clone[keys[i]] = val;
+    } else if (Array.isArray(val)) {
+      clone[keys[i]] = duplicateArr(val, references);
+    } else {
+      clone[keys[i]] = duplicateObj(val, references);
+    }
+  }
+  return clone;
 }
 
 api.common.getByPath = (

--- a/lib/data.js
+++ b/lib/data.js
@@ -50,15 +50,16 @@ function cloneObj(obj) {
   const clone = {};
   const keys = Object.keys(obj);
   const size = keys.length;
-  let i, val;
+  let i, key, val;
   for (i = 0; i < size; i++) {
-    val = obj[keys[i]];
+    key = keys[i];
+    val = obj[key];
     if (typeof(val) !== 'object' || val === null) {
-      clone[keys[i]] = val;
+      clone[key] = val;
     } else if (Array.isArray(val)) {
-      clone[keys[i]] = cloneArr(val);
+      clone[key] = cloneArr(val);
     } else {
-      clone[keys[i]] = cloneObj(val);
+      clone[key] = cloneObj(val);
     }
   }
   return clone;
@@ -95,17 +96,18 @@ function duplicateObj(obj, references) {
   references.set(obj, clone);
   const keys = Object.keys(obj);
   const size = keys.length;
-  let i, val;
+  let i, key, val;
   for (i = 0; i < size; i++) {
-    val = obj[keys[i]];
+    key = keys[i];
+    val = obj[key];
     if (references.has(val)) {
-      clone[keys[i]] = references.get(val);
+      clone[key] = references.get(val);
     } else if (typeof(val) !== 'object' || val === null) {
-      clone[keys[i]] = val;
+      clone[key] = val;
     } else if (Array.isArray(val)) {
-      clone[keys[i]] = duplicateArr(val, references);
+      clone[key] = duplicateArr(val, references);
     } else {
-      clone[keys[i]] = duplicateObj(val, references);
+      clone[key] = duplicateObj(val, references);
     }
   }
   return clone;


### PR DESCRIPTION
* Rewrite `clone` so it properly copies a prototype.
  This way we will need only one method instead of 3
* Add optional clone depth parameter