### PR TITLE
 Optimize GUID generation

### DIFF
--- a/lib/id.js
+++ b/lib/id.js
@@ -31,11 +31,13 @@ const generateStorageKey = (
   return [folder1, folder2, code];
 };
 
+const guidPrefetcher = math.cryptoPrefetcher(4096, 16);
+
 const generateGUID = (
   // Generate an RFC4122-compliant GUID (UUID v4)
   // Returns: string, GUID
 ) => {
-  const bytes = crypto.randomBytes(128);
+  const bytes = guidPrefetcher.next();
 
   bytes[6] &= 0x0F;
   bytes[6] |= 0x40;


### PR DESCRIPTION
GUID generation will now ask only for 16 bytes random bytes instead of 128, and will also take advantage of prefetching.

This PR is based on https://github.com/metarhia/common/pull/125 and must be landed after it.