### PR TITLE
Refactor enum class

### DIFF
--- a/lib/enum.js
+++ b/lib/enum.js
@@ -1,61 +1,54 @@
 'use strict';
 
-class Enum {}
+const NaE = Symbol('NotAnEnum');
 
-const enumArray = values => class extends Enum {
-  constructor(val) {
-    super();
-    this.value = this.constructor.key(val);
+class Enum {
+  static from(...args) {
+    let values = args[0];
+    if (typeof values !== 'object') {
+      values = args;
+    }
+    const enumValues = new Map();
+    const EnumClass = class extends Enum {
+      static from(val) {
+        return enumValues.get(val) || Enum.NaE;
+      }
+      static get values() {
+        return values;
+      }
+      static has(value) {
+        return enumValues.has(value);
+      }
+      static key(value) {
+        const e = enumValues.get(value);
+        return e ? e.index : undefined;
+      }
+      [Symbol.toPrimitive]() {
+        return this.index;
+      }
+    };
+    const withData = !Array.isArray(values);
+    let i = 0;
+    for (const key in values) {
+      const e = new EnumClass();
+      e.index = i++;
+      if (withData) {
+        e.value = key;
+        e.data = values[key];
+      } else {
+        e.value = values[key];
+      }
+      enumValues.set(e.value, e);
+    }
+    return EnumClass;
   }
-  static get collection() {
-    return values;
-  }
-  static has(val) {
-    return values.includes(val);
-  }
-  static key(val) {
-    return values.includes(val) ? val : undefined;
-  }
-  [Symbol.toPrimitive]() {
-    return this.value;
-  }
-};
+}
 
-const enumCollection = values => {
-  const index = {};
-  for (const key in values) {
-    const value = values[key];
-    index[value] = key;
-  }
-  return class extends Enum {
-    constructor(val) {
-      super();
-      this.value = this.constructor.key(val);
-    }
-    static get collection() {
-      return values;
-    }
-    static has(val) {
-      return !!(values[val] || index[val]);
-    }
-    static key(val) {
-      const value = values[val];
-      return value ? val : index[val];
-    }
-    [Symbol.toPrimitive](hint) {
-      const value = this.value;
-      if (hint === 'number') return parseInt(value, 10);
-      return values[value];
-    }
-  };
-};
-
-Enum.from = (...args) => {
-  const item = args[0];
-  const itemType = typeof(item);
-  if (itemType === 'object') return enumCollection(item);
-  if (itemType !== 'string') return enumArray(args);
-  return enumCollection(Object.assign({}, args));
-};
+Object.defineProperty(Enum, 'NaE', {
+  configurable: false,
+  enumerable: false,
+  writable: false,
+  value: NaE,
+});
 
 module.exports = { Enum };

--- a/test/enum.js
+++ b/test/enum.js
@@ -19,50 +19,52 @@ api.metatests.test('Enum with key/value', (test) => {
   });
 
   test.strictSame(typeof(Month), 'function');
-  test.strictSame(typeof(Month.collection), 'object');
-  test.strictSame(Array.isArray(Month.collection), false);
+  test.strictSame(typeof(Month.values), 'object');
+  test.strictSame(Array.isArray(Month.values), false);
 
   test.strictSame(Month.has('May'), true);
-  test.strictSame(Month.key('August'), 'Aug');
+  test.strictSame(Month.key('Aug'), 7);
 
-  const may = new Month('May');
+  const may = Month.from('May');
   test.strictSame(typeof(may), 'object');
-  test.strictSame(Month.has('May'), true);
   test.strictSame(may.value, 'May');
+  test.strictSame(may.index, 4);
+  test.strictSame(may.data, 'May');
 
-  test.strictSame(+may, NaN);
-  test.strictSame(may + '', 'May');
+  test.strictSame(+may, 4);
+  test.strictSame(may + '', '4');
 
   test.end();
 });
 
-api.metatests.test('Enum string keys', (test) => {
+api.metatests.test('Enum string month keys', (test) => {
   const Month = Enum.from(
     'January', 'February', 'March', 'April', 'May', 'June',
     'July', 'August', 'September', 'October', 'November', 'December'
   );
 
   test.strictSame(typeof(Month), 'function');
-  test.strictSame(typeof(Month.collection), 'object');
-  test.strictSame(Array.isArray(Month.collection), false);
+  test.strictSame(Array.isArray(Month.values), true);
 
   test.strictSame(Month.has('May'), true);
   test.strictSame(Month.has('Aug'), false);
-  test.strictSame(Month.key('August'), '7');
+  test.strictSame(Month.key('August'), 7);
 
-  const may = new Month('May');
+  const may = Month.from('May');
   test.strictSame(typeof(may), 'object');
   test.strictSame(Month.has('May'), true);
-  test.strictSame(may.value, '4');
+  test.strictSame(may.value, 'May');
+  test.strictSame(may.index, 4);
+  test.strictSame(may.data, undefined);
 
   test.strictSame(+may, 4);
-  test.strictSame(may + '', 'May');
+  test.strictSame(may + '', '4');
 
   test.end();
 });
 
-api.metatests.test('Enum string keys', (test) => {
-  const Month  = Enum.from({
+api.metatests.test('Enum string month typed keys', (test) => {
+  const Month = Enum.from({
     1: 'January',
     2: 'February',
     3: 'March',
@@ -78,60 +80,77 @@ api.metatests.test('Enum string keys', (test) => {
   });
 
   test.strictSame(typeof(Month), 'function');
-  test.strictSame(typeof(Month.collection), 'object');
-  test.strictSame(Array.isArray(Month.collection), false);
+  test.strictSame(typeof(Month.values), 'object');
+  test.strictSame(Array.isArray(Month.values), false);
 
-  test.strictSame(Month.has('May'), true);
-  test.strictSame(Month.has('Aug'), false);
-  test.strictSame(Month.key('August'), '8');
+  test.strictSame(Month.has('5'), true);
+  test.strictSame(Month.has(13), false);
 
-  const may = new Month('May');
+  const may = Month.from('5');
   test.strictSame(typeof(may), 'object');
-  test.strictSame(Month.has('May'), true);
   test.strictSame(may.value, '5');
+  test.strictSame(may.index, 4);
+  test.strictSame(may.data, 'May');
 
-  test.strictSame(+may, 5);
-  test.strictSame(may + '', 'May');
+  test.strictSame(+may, 4);
+  test.strictSame(may + '', '4');
 
   test.end();
 });
 
-api.metatests.test('Enum string keys', (test) => {
+api.metatests.test('Enum hundreds keys', (test) => {
   const Hundreds = Enum.from(100, 200, 300, 400, 500);
 
-  const neg = new Hundreds(-1);
-  const zero = new Hundreds(0);
-  const h100 = new Hundreds(100);
-  const h200 = new Hundreds(200);
-  const h500 = new Hundreds(500);
-  const h600 = new Hundreds(600);
-  const unknown = new Hundreds('Hello');
+  const h100 = Hundreds.from(100);
+  const h200 = Hundreds.from(200);
+  const h500 = Hundreds.from(500);
+
+  test.strictSame(Hundreds.from(-1), Enum.NaE);
+  test.strictSame(Hundreds.from(0), Enum.NaE);
+  test.strictSame(Hundreds.from(600), Enum.NaE);
+  test.strictSame(Hundreds.from('Hello'), Enum.NaE);
 
   test.strictSame(typeof(Hundreds), 'function');
-  test.strictSame(typeof(Hundreds.collection), 'object');
-  test.strictSame(Array.isArray(Hundreds.collection), true);
-  test.strictSame(Hundreds.collection.length, 5);
+  test.strictSame(Array.isArray(Hundreds.values), true);
+  test.strictSame(Hundreds.values.length, 5);
 
-  test.strictSame(+neg, NaN);
-  test.strictSame(neg + '', 'undefined');
+  test.strictSame(h100.value, 100);
+  test.strictSame(h100.index, 0);
+  test.strictSame(h100.data, undefined);
 
-  test.strictSame(+zero, NaN);
-  test.strictSame(zero + '', 'undefined');
+  test.strictSame(+h100, 0);
+  test.strictSame(h100 + '', '0');
+  test.strictSame(h100.value, 100);
 
-  test.strictSame(+h100, 100);
-  test.strictSame(h100 + '', '100');
+  test.strictSame(+h200, 1);
+  test.strictSame(h200 + '', '1');
+  test.strictSame(h200.value, 200);
 
-  test.strictSame(+h200, 200);
-  test.strictSame(h200 + '', '200');
-
-  test.strictSame(+h500, 500);
-  test.strictSame(h500 + '', '500');
-
-  test.strictSame(+h600, NaN);
-  test.strictSame(h600 + '', 'undefined');
-
-  test.strictSame(+unknown, NaN);
-  test.strictSame(unknown + '', 'undefined');
+  test.strictSame(+h500, 4);
+  test.strictSame(h500 + '', '4');
+  test.strictSame(h500.value, 500);
 
   test.end();
+});
+
+api.metatests.test('Enum hundreds keys array', (test) => {
+  const Hundreds = Enum.from([100, 200, 300, 400, 500]);
+
+  test.strictSame(Hundreds.from(0), Enum.NaE);
+
+  const h100 = Hundreds.from(100);
+  test.strictSame(h100.value, 100);
+  test.strictSame(h100.index, 0);
+  test.strictSame(h100.data, undefined);
+
+  test.end();
+});
+
+api.metatests.test('Enum.NaE property', (test) => {
+  test.strictSame(Object.getOwnPropertyDescriptor(Enum, 'NaE'), {
+    writable: false,
+    enumerable: false,
+    configurable: false,
+    value: Enum.NaE,
+  });
 });


### PR DESCRIPTION
* collection -> values
* toPrimitive now only reports enum index and not key or value
* cache enumArray into Map
* return special values Enum.NaE upon creation of enum from
  non-existent value
* introduce static .from to get enum instance from a value
* change enum properties: index - enum internal number, value - user
  passed key, data - optional use passed data

Need input on toPrimitive change (don't understand why it was returning one or the other depending on type-hint) and `.from` method.