### PR TITLE
Replace incorrect result value in network.ipToInt test

### DIFF
--- a/test/network.js
+++ b/test/network.js
@@ -7,7 +7,7 @@ api.metatests.case('Common / network', {
     ['192.168.1.10',    -1062731510],
     ['165.225.133.150', -1511946858],
     ['0.0.0.0',                   0],
-    ['wrong-string',           null],
+    ['wrong-string',     Number.NaN],
     ['',                          0],
     ['8.8.8.8',          0x08080808],
     [undefined,          0x7F000001],


### PR DESCRIPTION
Previous testing framework tested this incorrectly (NaN was equal to null in declarative tests).

Also if we really want `ipToInt` to return `null` in such cases I will then change the code. Though I think it's correct to return NaN because it's supposed to convert to a number, which NaN is.

Refs: https://github.com/metarhia/metatests/pull/64