### PR TITLE
Improve performance of subst by removing regexp

### DIFF
--- a/lib/strings.js
+++ b/lib/strings.js
@@ -45,7 +45,7 @@ const subst = (
     start = end + 1;
     end = tpl.indexOf('@', start);
     if (end === -1) {
-      start -= 1;
+      start--;
       break;
     }
 

--- a/lib/strings.js
+++ b/lib/strings.js
@@ -26,8 +26,6 @@ const htmlEscape = (
   content.replace(HTML_ESCAPE_REGEXP, char => HTML_ESCAPE_CHARS[char])
 );
 
-const SUBST_REGEXP = /@([-.0-9a-zA-Z]+)@/g;
-
 const subst = (
   // Substitute variables
   tpl, // string, template body
@@ -35,35 +33,60 @@ const subst = (
   dataPath, // string, current position in data structure
   escapeHtml // boolean, escape html special characters if true
   // Returns: string
-) => (
-  tpl.replace(SUBST_REGEXP, (s, key) => {
-    const pos = key.indexOf('.');
-    const name = pos === 0 ? dataPath + key : key;
-    let value = getByPath(data, name);
+) => {
+  let start = 0;
+  let end = tpl.indexOf('@');
+  if (end === -1) return tpl;
+
+  const defaultData = getByPath(data, dataPath);
+  let result = '';
+  while (end !== -1 && start < tpl.length) {
+    result = tpl.substring(start, end);
+    start = end + 1;
+    end = tpl.indexOf('@', start);
+    if (end === -1) {
+      start -= 1;
+      break;
+    }
+
+    let key;
+    let d;
+    if (tpl.charAt(start) !== '.') {
+      key = tpl.slice(start, end);
+      d = data;
+    } else {
+      key = tpl.slice(start + 1, end);
+      d = defaultData;
+    }
+
+    let value = getByPath(d, key);
     if (value === undefined) {
-      if (key === '.value') {
-        value = getByPath(data, dataPath);
-      } else {
-        value = '[undefined]';
-      }
+      value = key === '.value' ? d : '[undefined]';
     }
     if (value === null) {
       value = '[null]';
     } else if (value === undefined) {
       value = '[undefined]';
     } else if (typeof value === 'object') {
-      if (value.constructor.name === 'Date') {
+      const parentName = value.constructor.name;
+      if (parentName === 'Date') {
         value = nowDateTime(value);
-      } else if (value.constructor.name === 'Array') {
+      } else if (parentName === 'Array') {
         value = '[array]';
       } else {
         value = '[object]';
       }
     }
-    if (escapeHtml) value = htmlEscape(value);
-    return value;
-  })
-);
+    result += escapeHtml ? htmlEscape(value) : value;
+    start = end + 1;
+    end = tpl.indexOf('@', start);
+  }
+  if (start < tpl.length && end === -1) {
+    result += tpl.substring(start);
+  }
+  end = tpl.indexOf('@', start);
+  return result;
+};
 
 const fileExt = (
   // Extract file extension in lower case with no dot

--- a/test/strings.js
+++ b/test/strings.js
@@ -4,8 +4,12 @@
 
 api.metatests.case('Metarhia common library', {
   'common.subst': [
-    ['Hello, @name@', { name: 'Ali' }, '', true,                      'Hello, Ali'],
-    ['Hello, @.name@', { person: { name: 'Ali' } }, 'person', true,   'Hello, Ali'],
+    ['Hello, name', { name: 'Ali' }, '', true,                                     'Hello, name'],
+    ['Hello, @date@', { date: new Date(0) }, '', true,                 'Hello, 1970-01-01 00:00'],
+    ['Hello, @n@', { name: 'Ali' }, '', true,                               'Hello, [undefined]'],
+    ['Hello, @name@', { name: null }, '', true,                                  'Hello, [null]'],
+    ['Hello, @name@', { name: 'Ali' }, '', true,                                    'Hello, Ali'],
+    ['Hello, @.name@', { person: { name: 'Ali' } }, 'person', true,                 'Hello, Ali'],
   ],
   'common.section': [
     ['All you need is JavaScript', 'is',   ['All you need ', ' JavaScript']],


### PR DESCRIPTION
Should be finished but I haven't extensively tested this, therefore, WIP for now.

As we haven't finished our benchmarking I tested on node benches.
(2 mil iterations, 30 runs each configuration)
```
                                                                                        confidence improvement accuracy (*)   (**)  (***)
 tempBench/subst.js asdf@aaa@aaa, 2000000                                                      ***     73.04 %       ±4.15% ±5.55% ±7.27%
 tempBench/subst.js df@aaa@ asdklf jas 3r ,., @bbb@@ccc@ @ccc@ asdasdasdwwwwww, 2000000        ***     55.51 %       ±3.37% ±4.49% ±5.87%
```
bench https://gist.github.com/lundibundi/b82eaca7833dd649f496497a0c64f82b

