### PR TITLE
Implement mergeObjects to merge with user function

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -202,6 +202,30 @@ const merge = (
   return [...unique];
 };
 
+const mergeObjects = (
+  // Merge multiple object with merger
+  merger,
+  ...objs // array of objects
+  // Returns: object
+) => {
+  const keys = new Set();
+  for (const obj of objs) {
+    for (const key in obj) {
+      keys.add(key);
+    }
+  }
+
+  const result = {};
+  for (const key of keys) {
+    const args = new Array(objs.length);
+    for (let i = 0; i < objs.length; ++i) {
+      args[i] = objs[i][key];
+    }
+    result[key] = merger(...args);
+  }
+  return result;
+};
+
 module.exports = {
   isScalar,
   copy,
@@ -211,4 +235,5 @@ module.exports = {
   setByPath,
   deleteByPath,
   merge,
+  mergeObjects,
 };

--- a/test/data.js
+++ b/test/data.js
@@ -58,6 +58,11 @@ api.metatests.case('Common / data types', {
     [[1, 2, 3],  [1, 2, 3],              [1, 2, 3]],
     [[1, 2, 3],  [4, 5, 1],        [1, 2, 3, 4, 5]],
   ],
+  'common.mergeObjects': [
+    [(a, b) => a + b,               { a: 'a', b: 'b' }, { a: 'a', b: 'c' },    { a: 'aa', b: 'bc' }],
+    [(a, b) => a || b,              { a: 'a' }, { d: 'd', a: 'c' },              { a: 'a', d: 'd' }],
+    [(a, b) => (a || 0) + (b || 0), { a: 1, b: 2, c: 3 }, { a: 1, b: 2 },      { a: 2, b: 4, c: 3 }],
+  ],
 });
 
 api.metatests.test('setByPath', (test) => {


### PR DESCRIPTION
This will allow to avoid writing a lot of boilerplate code when you need
to merge two (or more) objects using specific resolution mechanism for
values under the same keys.