### PR TITLE
Refactor submodules require

### DIFF
--- a/common.js
+++ b/common.js
@@ -19,6 +19,6 @@ const submodules = [
   'mp', // Metaprogramming
   'enum', // Enumerated type
   'iterator', // Iterator
-].map(path => './lib/' + path).map(require);
+].map(path => require('./lib/' + path));
 
 module.exports = Object.assign({}, ...submodules);


### PR DESCRIPTION
Refs: https://github.com/metarhia/metatests/issues/74
In order to be able to run metatests in browser, webpack should be able to parse files and preload modules. More about it here: https://github.com/metarhia/metatests/pull/75#issuecomment-416203241