### PR TITLE
Implement Iterator.someCount(pred, count, thisArg)

### DIFF
--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -86,6 +86,16 @@ class Iterator {
     return false;
   }
 
+  someCount(predicate, count, thisArg) {
+    let n = 0;
+    for (const value of this) {
+      if (predicate.call(thisArg, value)) {
+        if (++n === count) return true;
+      }
+    }
+    return false;
+  }
+
   collectTo(CollectionClass) {
     return new CollectionClass(this);
   }

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -293,6 +293,26 @@ metatests.test('Iterator.some with thisArg', test => {
   test.end();
 });
 
+metatests.testSync('Iterator.someCount that must return true', test => {
+  test.assert(iter(array).someCount(element => element % 2, 2));
+});
+
+metatests.testSync('Iterator.someCount that must return false', test => {
+  test.assertNot(iter(array).someCount(element => element % 2, 3));
+  test.assertNot(iter(array).someCount(element => element < 0, 1));
+});
+
+metatests.testSync('Iterator.someCount with thisArg', test => {
+  const obj = {
+    max: 3,
+    predicate(value) {
+      return value < this.max;
+    },
+  };
+
+  test.assert(iter(array).someCount(obj.predicate, 2, obj));
+});
+
 metatests.test('Iterator.find that must find an element', test => {
   test.strictSame(iter(array).find(element => element % 2 === 0), 2);
   test.end();


### PR DESCRIPTION
This will allow to avoid filtering the whole Iterator when you
need to know if at least 'count' elements satisfy the predicate
(this could be done with 'filter -> count' but that wouldn't provide an
early exit in case of success).