### PR TITLE
Fix invalid handling of Object class instances in `duplicate()`

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -89,9 +89,14 @@ duplicateArray = (arr, references) => {
 };
 
 duplicateObject = (obj, references) => {
-  const object = (obj.constructor && obj.constructor !== Object) ?
-    new obj.constructor(obj.toString()) :
-    Object.create(null);
+  let object;
+  if (!obj.constructor) {
+    object = Object.create(null);
+  } else if (obj.constructor !== Object) {
+    object = new obj.constructor(obj.toString());
+  } else {
+    object = {};
+  }
   references.set(obj, object);
   const keys = Object.keys(obj);
   for (let i = 0; i < keys.length; i++) {

--- a/test/data.js
+++ b/test/data.js
@@ -125,3 +125,14 @@ metatests.test('deleteByPath non-existent last', (test) => {
   test.assertNot(common.deleteByPath(obj, 'a.b.c'));
   test.end();
 });
+
+metatests.test('duplicate correctly handling object prototypes', test => {
+  const objects = [
+    {}, new Date(), Object.create(null),
+  ];
+  objects.forEach(obj => {
+    const res = common.duplicate(obj);
+    test.strictSame(obj.constructor, res.constructor);
+  });
+  test.end();
+});


### PR DESCRIPTION
Fixes: https://github.com/metarhia/globalstorage/issues/253