### PR TITLE
Fix incorrect behavior in Uint64 constructor

### DIFF
--- a/lib/uint64.js
+++ b/lib/uint64.js
@@ -15,6 +15,12 @@ const charToNum = {
   f: 15, F: 15,
 };
 
+const radixStr = {
+  '0x': 16,
+  '0o': 8,
+  '0b': 2,
+};
+
 class Uint64 {
   constructor(value) {
     this.value = new Uint32Array(2);
@@ -33,17 +39,10 @@ class Uint64 {
       this.value[0] = numValue % (UINT32_MAX + 1);
       this.value[1] = Math.floor(numValue / (UINT32_MAX + 1));
     } else if (typeof value === 'string') {
-      let radix = 10;
-      if (value.startsWith('0x')) {
-        radix = 16;
-      } else if (value.startsWith('0o')) {
-        radix = 8;
-      } else if (value.startsWith('0b')) {
-        radix = 2;
-      }
+      const radix = radixStr[value.slice(0, 2)] || 10;
       const uintRadix = new Uint64(radix);
       let res = new Uint64();
-      for (let i = 0; i < value.length; i++) {
+      for (let i = radix !== 10 ? 2 : 0; i < value.length; i++) {
         const digit = charToNum[value[i]];
         const uintDigit = new Uint64(digit);
         res = Uint64.mult(res, uintRadix).add(uintDigit);

--- a/test/uint64.js
+++ b/test/uint64.js
@@ -469,6 +469,12 @@ metatests.test('Uint64.constructor()', test => {
     },
     {
       value:
+        '0b10101010101010101010101010101010101010101010101010101010101010',
+      expectedString: '3074457345618258602',
+      message: 'must create Uint64 from a big bin number provided as a string',
+    },
+    {
+      value:
         '0b1010101010101010101010101010101010101010101010101010101010101010',
       expectedString: '12297829382473034410',
       message: 'must create Uint64 from a big bin number provided as a string',


### PR DESCRIPTION
It resulted in invalid values being created when passing a binary
number with digit count between 53 and 63 to the constructor as a
string.
Also, refactor and optimize creation of values from strings representing
numbers in other numeral systems.
