### PR TITLE
Rename join -> chain and impl Iterator.join similar to Array.join

### DIFF
--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -159,6 +159,18 @@ class Iterator {
   enumerate() {
     return new EnumerateIterator(this);
   }
+
+  join(sep = ',', prefix = '', suffix = '') {
+    let result = prefix;
+    const { done, value } = this.next();
+    if (!done) {
+      result += value;
+      for (const value of this) {
+        result += sep + value;
+      }
+    }
+    return result + suffix;
+  }
 }
 
 class MapIterator extends Iterator {

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -137,8 +137,8 @@ class Iterator {
     return new ZipIterator(this, iterators);
   }
 
-  join(...iterators) {
-    return new JoinIterator(this, iterators);
+  chain(...iterators) {
+    return new ChainIterator(this, iterators);
   }
 
   take(amount) {
@@ -321,7 +321,7 @@ class ZipIterator extends Iterator {
   }
 }
 
-class JoinIterator extends Iterator {
+class ChainIterator extends Iterator {
   constructor(base, iterators) {
     super(base);
     this.currentIterator = base;

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -231,7 +231,7 @@ metatests.test('Iterator.zip', test => {
   test.end();
 });
 
-metatests.test('Iterator.join', test => {
+metatests.test('Iterator.chain', test => {
   const it = iter(array).take(1);
   const itr = iter(array)
     .skip(1)
@@ -239,7 +239,7 @@ metatests.test('Iterator.join', test => {
   const iterator = iter(array)
     .skip(2)
     .take(2);
-  test.strictSame(it.join(itr, iterator).toArray(), [1, 2, 3, 4]);
+  test.strictSame(it.chain(itr, iterator).toArray(), [1, 2, 3, 4]);
   test.end();
 });
 

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -407,3 +407,28 @@ metatests.testSync('Iterator.enumerate must start from 0', test => {
     i++;
   });
 });
+
+metatests.testSync('Iterator.join default', test => {
+  const actual = iter(array).join();
+  test.strictSame(actual, '1,2,3,4');
+});
+
+metatests.testSync('Iterator.join', test => {
+  const actual = iter(array).join(', ');
+  test.strictSame(actual, '1, 2, 3, 4');
+});
+
+metatests.testSync('Iterator.join with prefix', test => {
+  const actual = iter(array).join(', ', 'a = ');
+  test.strictSame(actual, 'a = 1, 2, 3, 4');
+});
+
+metatests.testSync('Iterator.join with suffix', test => {
+  const actual = iter(array).join(', ', '', ' => 10');
+  test.strictSame(actual, '1, 2, 3, 4 => 10');
+});
+
+metatests.testSync('Iterator.join with prefix and suffix', test => {
+  const actual = iter(array).join(', ', '[', ']');
+  test.strictSame(actual, '[1, 2, 3, 4]');
+});


### PR DESCRIPTION
* Rename join to chain iterator
This will be a bit more clear and allow to implement 'join' the
similar to the definition in the Array.

* Implement Iterator.join similar to Array.join
It also supports prefix and suffix parameters.