### PR TITLE
Fix argument name collision in `validateHash()`

### DIFF
--- a/lib/id.js
+++ b/lib/id.js
@@ -126,11 +126,12 @@ const hash = (password, salt) => crypto.createHmac('sha512', salt)
   .digest('hex');
 
 // Validate hash
-//   hash - <string>
+//   hashValue - <string>
 //   password - <string>
 //   salt - <string>
 // Returns: <boolean>
-const validateHash = (hash, password, salt) => hash(password, salt) === hash;
+const validateHash = (hashValue, password, salt) =>
+  hash(password, salt) === hashValue;
 
 // Convert id to array of hex strings
 //   id - <number>

--- a/test/id.js
+++ b/test/id.js
@@ -100,3 +100,11 @@ metatests.test('generateStorageKey', test => {
   test.strictSame(key.join('/').length, 14);
   test.end();
 });
+
+metatests.test('common.hash() with common.validateHash()', test => {
+  const password = 'password';
+  const salt = 'salt';
+  const hashValue = common.hash(password, salt);
+  test.assert(common.validateHash(hashValue, password, salt));
+  test.end();
+});


### PR DESCRIPTION
Fixes: https://github.com/metarhia/common/issues/235