### PR TITLE
Fix duplicate() and clone() regression

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -21,7 +21,9 @@ const clone = val => {
   }
   const objOrArray = Array.isArray(val) ? new Array(val.length) : {};
   for (const key in val) {
-    objOrArray[key] = clone(val[key]);
+    if (val.hasOwnProperty(key)) {
+      objOrArray[key] = clone(val[key]);
+    }
   }
   return objOrArray;
 };
@@ -42,6 +44,9 @@ const duplicateWithReferences = (val, references) => {
   }
   references.set(val, objOrArray);
   for (const key in val) {
+    if (!val.hasOwnProperty(key)) {
+      continue;
+    }
     const reference = references.get(val[key]);
     if (reference !== undefined) {
       objOrArray[key] = reference;

--- a/test/data.js
+++ b/test/data.js
@@ -136,3 +136,17 @@ metatests.test('duplicate correctly handling object prototypes', test => {
   });
   test.end();
 });
+
+metatests.test('duplicate handling only object own properties', test => {
+  const buf = Buffer.from('test data');
+  const res = common.duplicate(buf);
+  test.strictSame(buf, res);
+  test.end();
+});
+
+metatests.test('clone handling only object own properties', test => {
+  const buf = Buffer.from('test data');
+  const res = common.clone(buf);
+  test.strictSame(buf, res);
+  test.end();
+});


### PR DESCRIPTION
Patch from https://github.com/metarhia/common/pull/85 has introduced a regression in `duplicate()` and `clone()` methods by iterating over Object's properties available from its prototype chain.
This was leading to `TypeError`s in some situations, in particular when cloning Buffer values.

Related CI: https://travis-ci.org/metarhia/metaschema/jobs/466122630