### PR TITLE
Fix `duplicateWithReferences`

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -46,7 +46,7 @@ const duplicateWithReferences = (val, references) => {
   }
   references.set(val, objOrArray);
   for (const key in val) {
-    if (!val.hasOwnProperty(key)) {
+    if (!Object.prototype.hasOwnProperty.call(val, key)) {
       continue;
     }
     const reference = references.get(val[key]);


### PR DESCRIPTION
Previous version won't work with objects, that have no prototype, as they don't have `hasOwnProperty` method