### PR TITLE
Remove outdated common.inherits()

### DIFF
--- a/lib/oop.js
+++ b/lib/oop.js
@@ -1,10 +1,5 @@
 'use strict';
 
-const inherits = (child, base) => {
-  child.super_ = base;
-  Object.setPrototypeOf(child.prototype, base.prototype);
-};
-
 // Override method: save old to `fn.inherited`
 // Previous function will be accessible by obj.fnName.inherited
 //   obj - <Object>, containing method to override
@@ -29,7 +24,6 @@ const mixin = (target, source) => {
 };
 
 module.exports = {
-  inherits,
   override,
   mixin,
 };


### PR DESCRIPTION
There is no point in keeping this function since there is an equivalent
[`util.inherits()`](https://nodejs.org/api/util.html#util_util_inherits_constructor_superconstructor) function provided by Node.js since v0.3.0.