### PR TITLE
Remove deprecated functions and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,6 @@ Create Cache, enhanced Map
 
 ### class Cache
 
-#### Cache.super\_()
-
 #### Cache.prototype.constructor()
 
 #### Cache.prototype.add(key, val)
@@ -246,8 +244,6 @@ _Returns:_ [`<Function>`][function] function(...args) wrapped callback
 
 Wrap function: call once, not null
 
-### cb(...args)
-
 ### unsafeCallback(args)
 
 - `args`: [`<Array>`][array] arguments
@@ -258,10 +254,6 @@ Extract callback function
 
 It's unsafe: may return null, allows multiple calls
 
-### extractCallback(...args)
-
-### cbUnsafe(...args)
-
 ### safeCallback(args)
 
 - `args`: [`<Array>`][array] arguments
@@ -270,8 +262,6 @@ _Returns:_ [`<Function>`][function] callback or common.emptiness if there is no
 callback
 
 Extract callback
-
-### cbExtract(...args)
 
 ### requiredCallback(args)
 
@@ -455,9 +445,7 @@ with wildcard and forward method
 
 ### class EnhancedEmitter
 
-#### EnhancedEmitter.super\_()
-
-#### EnhancedEmitter.prototype.constructor()
+#### EnhancedEmitter.prototype.constructor(...args)
 
 #### EnhancedEmitter.prototype.emit(...args)
 
@@ -645,41 +633,6 @@ Generate random key
 _Returns:_ [`<string>`][string] GUID
 
 Generate an RFC4122-compliant GUID (UUID v4)
-
-### generateSID(config)
-
-- `config`: [`<Object>`][object] { length, characters, secret }
-
-_Returns:_ [`<string>`][string] SID
-
-Generate random SID
-
-_Deprecated:_ this method will be removed in the next major versions. Use
-`generateToken()` instead.
-
-### crcSID(config, key)
-
-- `config`: [`<Object>`][object] { secret }
-- `key`: [`<string>`][string] SID key
-
-_Returns:_ [`<string>`][string] CRC
-
-Calculate SID CRC
-
-_Deprecated:_ this method will be removed in the next major versions. Use
-`crcToken()` instead.
-
-### validateSID(config, sid)
-
-- `config`: [`<Object>`][object] { secret }
-- `sid`: [`<string>`][string] session id
-
-_Returns:_ [`<boolean>`][boolean]
-
-Validate SID
-
-_Deprecated:_ this method will be removed in the next major versions. Use
-`validateToken()` instead.
 
 ### generateToken(secret, characters, length)
 
@@ -938,8 +891,6 @@ _Returns:_ [`<string[]>`][string] property names
 
 List property names
 
-### ip2int(...args)
-
 ### ipToInt(\[ip\])
 
 - `ip`: [`<string>`][string] (optional), default: '127.0.0.1', IP address
@@ -961,8 +912,6 @@ Get local network interfaces
 _Returns:_ [`<string>`][string] host without port but not empty
 
 Parse host string
-
-### inherits(child, base)
 
 ### override(obj, fn)
 

--- a/lib/callbacks.js
+++ b/lib/callbacks.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { last } = require('./array');
-const { alias } = require('./utilities');
 
 // Empty function
 // Returns: <boolean>, always `false`
@@ -114,14 +113,8 @@ module.exports = {
   noop,
 
   once,
-  cb: alias(once),
-
   unsafeCallback,
-  extractCallback: alias(unsafeCallback),
-  cbUnsafe: alias(unsafeCallback),
-
   safeCallback,
-  cbExtract: alias(safeCallback),
 
   requiredCallback,
   onceCallback,

--- a/lib/id.js
+++ b/lib/id.js
@@ -49,42 +49,6 @@ const generateGUID = () => {
   ].join('-');
 };
 
-// Calculate SID CRC
-//   config - <Object>, { secret }
-//   key - <string>, SID key
-// Returns: <string>, CRC
-// Deprecated: this method will be removed in the next major versions.
-//     Use `crcToken()` instead.
-const crcSID = (config, key) =>
-  crypto
-    .createHash('md5')
-    .update(key + config.secret)
-    .digest('hex')
-    .substring(0, 4);
-
-// Generate random SID
-//   config - <Object>, { length, characters, secret }
-// Returns: <string>, SID
-// Deprecated: this method will be removed in the next major versions.
-//     Use `generateToken()` instead.
-const generateSID = config => {
-  const key = generateKey(config.length - 4, config.characters);
-  return key + crcSID(config, key);
-};
-
-// Validate SID
-//   config - <Object>, { secret }
-//   sid - <string>, session id
-// Returns: <boolean>
-// Deprecated: this method will be removed in the next major versions.
-//     Use `validateToken()` instead.
-const validateSID = (config, sid) => {
-  if (!sid) return false;
-  const crc = sid.substr(sid.length - 4);
-  const key = sid.substr(0, sid.length - 4);
-  return crcSID(config, key) === crc;
-};
-
 // Calculate Token crc
 //   secret <string>
 //   key <string>
@@ -184,9 +148,6 @@ const pathToId = path => {
 module.exports = {
   generateKey,
   generateGUID,
-  generateSID,
-  crcSID,
-  validateSID,
   generateToken,
   crcToken,
   validateToken,

--- a/lib/network.js
+++ b/lib/network.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const os = require('os');
-const { alias } = require('./utilities');
 
 // Convert IP string to number
 // Signature: [ip]
@@ -44,7 +43,6 @@ const parseHost = host => {
 };
 
 module.exports = {
-  ip2int: alias(ipToInt),
   ipToInt,
   localIPs,
   parseHost,

--- a/test/id.js
+++ b/test/id.js
@@ -10,43 +10,10 @@ const characters =
 const secret = 'secret';
 const length = 64;
 
-const config = {
-  characters: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789',
-  secret: 'secret',
-  length: 64,
-};
-
 metatests.case(
   'Common / id',
   { common },
   {
-    'common.validateSID': [
-      [
-        config,
-        'XFHczfaqXaaUmIcKfHNF9YAY4BRaMX5Z4Bx99rsB5UA499mTjmewlrWTKTCp77bc',
-        true,
-      ],
-      [
-        config,
-        'XFHczfaqXaaUmIcKfHNF9YAY4BRaMX5Z4Bx99rsB5UA499mTjmewlrWTKTCp77bK',
-        false,
-      ],
-      [
-        config,
-        '2XpU8oAewXwKJJSQeY0MByY403AyXprFdhB96zPFbpJxlBqHA3GfBYeLxgHxBhhZ',
-        false,
-      ],
-      [config, 'WRONG-STRING', false],
-      [config, '', false],
-    ],
-    'common.generateSID': [[config, result => result.length === 64]],
-    'common.crcSID': [
-      [
-        config,
-        common.generateKey(config.length - 4, config.characters),
-        result => result.length === 4,
-      ],
-    ],
     'common.validateToken': [
       [
         secret,


### PR DESCRIPTION
List of removed functions:

- `common.ip2int()` - replace with `common.ipToInt()`
- `common.cb()` - replace with `common.once()`
- `common.extractCallback()` - replace with `common.unsafeCallback()`
- `common.cbUnsafe()` - replace with `common.unsafeCallback()`
- `common.cbExtract()` - replace with `common.safeCallback()`
- `common.crcSID()` - replace with `common.crcToken()`
- `common.generateSID()` - replace with `common.generateToken()`
- `common.validateSID()` - replace with `common.validateToken()`