### PR TITLE
Remove deprecate() and alias() functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to
   - `common.crcSID()` - replace with `common.crcToken()`
   - `common.generateSID()` - replace with `common.generateToken()`
   - `common.validateSID()` - replace with `common.validateToken()`
+- Functions that can be replaced with `util.deprecate()` available in Node.js:
+  - `common.deprecate()`
+  - `common.alias()`
 
 ## [1.5.0][] - 2019-04-12
 

--- a/README.md
+++ b/README.md
@@ -1389,26 +1389,6 @@ _Returns:_ [`<number>`][number]
 
 Convert string with data size to integer
 
-### deprecate(fn)
-
-- `fn`: [`<Function>`][function]
-
-_Returns:_ [`<Function>`][function] wrapped with deprecation warning
-
-- `args`: [`<Array>`][array] arguments to be passed to wrapped function
-
-Wrap method to mark it as deprecated
-
-### alias(fn)
-
-- `fn`: [`<Function>`][function]
-
-_Returns:_ [`<Function>`][function] wrapped with deprecation warning
-
-- `args`: [`<Array>`][array] arguments to be passed to wrapped function
-
-Wrap new method to mark old alias as deprecated
-
 ### safe(fn)
 
 - `fn`: [`<Function>`][function]

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -2,45 +2,6 @@
 
 const { basename } = require('path');
 
-const { between } = require('./strings');
-
-// Wrap method to mark it as deprecated
-//   fn - <Function>
-// Returns: <Function>, wrapped with deprecation warning
-//   args - <Array>, arguments to be passed to wrapped function
-const deprecate = fn => {
-  let warned = false;
-  const wrap = (...args) => {
-    if (!warned) {
-      const err = new Error(`Warning: method ${fn.name} is deprecated`);
-      console.warn(err);
-      warned = true;
-    }
-    return fn(...args);
-  };
-  return wrap;
-};
-
-// Wrap new method to mark old alias as deprecated
-//   fn - <Function>
-// Returns: <Function>, wrapped with deprecation warning
-//   args - <Array>, arguments to be passed to wrapped function
-const alias = fn => {
-  let warned = false;
-  const wrap = (...args) => {
-    if (!warned) {
-      const err = new Error();
-      const name = between(err.stack, '[', ']');
-      err.message = `Warning: use ${fn.name} instead of deprecated ${name}`;
-      err.stack = err.stack.replace('Error', err.message);
-      console.warn(err);
-      warned = true;
-    }
-    return fn(...args);
-  };
-  return wrap;
-};
-
 // Make function raise-safe
 //   fn - <Function>
 // Returns: <Function>, function(...args), wrapped with try/catch interception
@@ -84,8 +45,6 @@ const callerFilename = (depth = 0, stack = null) =>
   basename(callerFilepath(depth + 1, stack) || '');
 
 module.exports = {
-  deprecate,
-  alias,
   safe,
   callerFilename,
   callerFilepath,


### PR DESCRIPTION
Usage of these functions can be replaced with `util.deprecate()`, which
is a built-in way for function deprecation in Node.js.