### PR TITLE
Make collectWith return the provided object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - This CHANGELOG.md file.
+- `Iterator#collectWith()` now returns the provided object.
 
 ### Changed
 

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -111,6 +111,7 @@ class Iterator {
 
   collectWith(obj, collector) {
     this.forEach(element => collector(obj, element));
+    return obj;
   }
 
   toArray() {

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -425,6 +425,14 @@ metatests.test(
   }
 );
 
+metatests.test('Iterator.collectWith must return provided object', test => {
+  const set = iter(array).collectWith(new Set(), (obj, element) => {
+    obj.add(element);
+  });
+  test.strictSame([...set.values()], array);
+  test.end();
+});
+
 metatests.testSync('Iterator.enumerate must return tuples', test => {
   let i = 0;
   iter(array)


### PR DESCRIPTION
This will make it consistent with other 'collection' methods.