### PR TITLE
Version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased][unreleased]
 
+## [2.0.0][] - 2019-04-26
+
 ### Added
 
 - This CHANGELOG.md file.
@@ -143,7 +145,8 @@ and this project adheres to
 
 - The first stable version of the `@metarhia/common` package.
 
-[unreleased]: https://github.com/metarhia/common/compare/v1.5.0...HEAD
+[unreleased]: https://github.com/metarhia/common/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/metarhia/common/compare/v1.5.0...v2.0.0
 [1.5.0]: https://github.com/metarhia/common/compare/v1.4.2...v1.5.0
 [1.4.2]: https://github.com/metarhia/common/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/metarhia/common/compare/v1.4.0...v1.4.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@metarhia/common",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metarhia/common",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "author": "Timur Shemsedinov <timur.shemsedinov@gmail.com>",
   "description": "Metarhia Common Library",
   "license": "MIT",


### PR DESCRIPTION
## Release summary:

Dropped support for Node.js 6; removed a bunch of deprecated and
outdated methods; replaced remaining ES5-style classes with ES6 classes,
and added changelog and utility methods for `Iterator`.

## Changelog:

### Added

- CHANGELOG.md file.
- `Iterator#collectWith()` now returns the provided object.
- `Iterator#toObject()` to collect iterable into an Object similar to
  [`Object.fromEntries()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries).
- `common.iterEntries()`, `common.iterKeys()`, `common.iterValues()` utility
  methods.

### Changed

- Expose `AuthenticationStrength`'s `compliance` number property instead of
  `strength` string.
- Replaced ES5-style classes and inheritance with ES6 classes for `Cache` and
  `EnhancedEmitter`.
- Signature of `merger()` in `mergeObjects()` to also contain the merging key.

### Removed

- Dropped support for Node.js 6.
- Outdated `inherits()` method (in favor of `util.inherits()` available in
  Node.js).
- Multiple deprecated functions:
  - `common.ip2int()` - replace with `common.ipToInt()`
  - `common.cb()` - replace with `common.once()`
  - `common.extractCallback()` - replace with `common.unsafeCallback()`
  - `common.cbUnsafe()` - replace with `common.unsafeCallback()`
  - `common.cbExtract()` - replace with `common.safeCallback()`
  - `common.crcSID()` - replace with `common.crcToken()`
  - `common.generateSID()` - replace with `common.generateToken()`
  - `common.validateSID()` - replace with `common.validateToken()`
- Functions that can be replaced with `util.deprecate()` available in Node.js:
  - `common.deprecate()`
  - `common.alias()`

### Fixed

- Functions `common.clone()`, `common.deleteByPath()`, and
  `common.mergeObjects()` throwing when used on objects without prototype.