### PR TITLE
Implement Iterator.skipWhile to enable skipping by predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - `Iterator#filterMap()` to enable more efficient filter+map. It will only
   return values from mapper function that do not match the passed
   filterValue (`undefined` by default).
+- `Iterator#skipWhile()` to enable skipping elements while predicate holds.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -861,6 +861,8 @@ This iterator will call `mapper` on each element and if mapper returns NOT
 
 #### Iterator.prototype.skip(amount)
 
+#### Iterator.prototype.skipWhile(predicate, thisArg)
+
 #### Iterator.prototype.some(predicate, thisArg)
 
 #### Iterator.prototype.someCount(predicate, count, thisArg)

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -179,6 +179,10 @@ class Iterator {
     return this;
   }
 
+  skipWhile(predicate, thisArg) {
+    return new SkipWhileIterator(this, predicate, thisArg);
+  }
+
   enumerate() {
     return new EnumerateIterator(this);
   }
@@ -441,6 +445,25 @@ class EnumerateIterator extends Iterator {
       return next;
     }
     return { done: false, value: [this.index++, next.value] };
+  }
+}
+
+class SkipWhileIterator extends Iterator {
+  constructor(base, predicate, thisArg) {
+    super(base);
+    this.predicate = predicate;
+    this.thisArg = thisArg;
+    this.doneSkipping = false;
+  }
+
+  next() {
+    let next = this.base.next();
+    if (this.doneSkipping) return next;
+    while (!next.done && this.predicate.call(this.thisArg, next.value)) {
+      next = this.base.next();
+    }
+    this.doneSkipping = true;
+    return next;
   }
 }
 

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -322,6 +322,41 @@ metatests.test('Iterator.skip', test => {
   test.end();
 });
 
+metatests.test('Iterator.skipWhile', test => {
+  const it = iter(array).skipWhile(v => v < 3);
+  test.strictSame(it.next().value, 3);
+  test.strictSame(it.next().value, 4);
+  test.assert(it.next().done);
+  test.end();
+});
+
+metatests.test(
+  'Iterator.skipWhile must stop skipping after first predicate failure',
+  test => {
+    const it = iter([1, 2, 3, 2, 1]).skipWhile(v => v < 3);
+    test.strictSame(it.next().value, 3);
+    test.strictSame(it.next().value, 2);
+    test.strictSame(it.next().value, 1);
+    test.assert(it.next().done);
+    test.end();
+  }
+);
+
+metatests.test('Iterator.skipWhile with thisArg', test => {
+  const obj = {
+    start: 3,
+    predicate(value) {
+      return value < this.start;
+    },
+  };
+
+  const it = iter(array).skipWhile(obj.predicate, obj);
+  test.strictSame(it.next().value, 3);
+  test.strictSame(it.next().value, 4);
+  test.assert(it.next().done);
+  test.end();
+});
+
 metatests.test('Iterator.every that must return true', test => {
   test.assert(iter(array).every(element => element > 0));
   test.end();


### PR DESCRIPTION
<!-- Brief summary of the changes: -->
This implements `skipWhile` on an `Iterator` to enable skipping using predicate similar to `takeWhile`.
<!--
Make sure you've completed all of the applicable tasks below.
Change [ ] to [x] for completed items.
-->

- [x] code is properly formatted (`npm run fmt`)
- [x] tests are added/updated
- [x] documentation is updated (`npm run doc` to regenerate documentation based on comments)
- [x] description of changes is added under the `Unreleased` header in CHANGELOG.md
