### PR TITLE
Implement Iterator.filterMap enabling more efficient filter+map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to
 ### Added
 
 - `rmRecursive()` and `rmRecursivePromise()` functions.
+- `Iterator#filterMap()` to enable more efficient filter+map. It will only
+  return values from mapper function that do not match the passed
+  filterValue (`undefined` by default).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -827,6 +827,20 @@ Create iterator iterating over the range
 
 #### Iterator.prototype.filter(predicate, thisArg)
 
+#### Iterator.prototype.filterMap(mapper\[, thisArg\[, filterValue\]\])
+
+- `mapper`: [`<Function>`][function] function that maps values and returns
+  either new value that will be the next value of the new iterator or
+  `filterValue` that will be ignored.
+  - `value`: `<any>` iterator element
+- `thisArg`: `<any>` value to be used as `this` when calling `mapper`
+- `filterValue`: `<any>` value to filter out `mapper` results.
+
+Creates an iterator that both filters and maps with the passed `mapper`.
+
+This iterator will call `mapper` on each element and if mapper returns NOT
+`filterValue` it will be returned, otherwise it is ignored.
+
 #### Iterator.prototype.find(predicate, thisArg)
 
 #### Iterator.prototype.flat(depth = 1)

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -134,6 +134,20 @@ class Iterator {
     return new FilterIterator(this, predicate, thisArg);
   }
 
+  // Creates an iterator that both filters and maps with the passed `mapper`.
+  // This iterator will call `mapper` on each element and if mapper returns
+  // NOT `filterValue` it will be returned, otherwise it is ignored.
+  // Signature: mapper[, thisArg[, filterValue]]
+  //   mapper <Function> function that maps values and returns either new value
+  //       that will be the next value of the new iterator or `filterValue`
+  //       that will be ignored.
+  //     value <any> iterator element
+  //   thisArg <any> value to be used as `this` when calling `mapper`
+  //   filterValue <any> value to filter out `mapper` results.
+  filterMap(mapper, thisArg, filterValue) {
+    return new FilterMapIterator(this, mapper, thisArg, filterValue);
+  }
+
   flat(depth = 1) {
     return new FlatIterator(this, depth);
   }
@@ -242,6 +256,25 @@ class FilterIterator extends Iterator {
     for (const value of this.base) {
       if (this.predicate.call(this.thisArg, value)) {
         return { done: false, value };
+      }
+    }
+    return { done: true, value: undefined };
+  }
+}
+
+class FilterMapIterator extends Iterator {
+  constructor(base, mapper, thisArg, filterValue) {
+    super(base);
+    this.mapper = mapper;
+    this.thisArg = thisArg;
+    this.filterValue = filterValue;
+  }
+
+  next() {
+    for (const value of this.base) {
+      const nextValue = this.mapper.call(this.thisArg, value);
+      if (nextValue !== this.filterValue) {
+        return { done: false, value: nextValue };
       }
     }
     return { done: true, value: undefined };

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -166,6 +166,43 @@ metatests.test('Iterator.filter with thisArg', test => {
   test.end();
 });
 
+metatests.test('Iterator.filterMap', test => {
+  test.strictSame(
+    iter(array)
+      .filterMap(value => (value > 2 ? value * 2 : undefined))
+      .toArray(),
+    [6, 8]
+  );
+  test.end();
+});
+
+metatests.test('Iterator.filterMap with thisArg', test => {
+  const obj = {
+    divider: 2,
+    predicate(value) {
+      return value % this.divider === 0 ? value * 2 : undefined;
+    },
+  };
+
+  test.strictSame(
+    iter(array)
+      .filterMap(obj.predicate, obj)
+      .toArray(),
+    [4, 8]
+  );
+  test.end();
+});
+
+metatests.test('Iterator.filterMap with filterValue', test => {
+  test.strictSame(
+    iter(array)
+      .filterMap(value => (value > 2 ? value * 2 : 42), null, 42)
+      .toArray(),
+    [6, 8]
+  );
+  test.end();
+});
+
 metatests.test('Iterator.flat', test => {
   const array = [[[[1], 2], 3], 4];
   const flatArray = [1, 2, 3, 4];


### PR DESCRIPTION
It will call mapper on every element just like .map but will also
filter out values returned from mapper that match
filterValue (undefined by default).

<!-- Brief summary of the changes: -->

<!--
Make sure you've completed all of the applicable tasks below.
Change [ ] to [x] for completed items.
-->

- [x] code is properly formatted (`npm run fmt`)
- [x] tests are added/updated
- [x] documentation is updated (`npm run doc` to regenerate documentation based on comments)
- [x] description of changes is added under the `Unreleased` header in CHANGELOG.md
