### PR TITLE
Throw on invalid arguments in CryptoRandomPrefetcher constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- `cryptoPrefetcher()` to throw when `bufSize` is not a multiple of
+  `valueSize`.
+
 ## [2.1.0][] - 2019-06-18
 
 ### Added

--- a/lib/math.js
+++ b/lib/math.js
@@ -4,6 +4,9 @@ const crypto = require('crypto');
 
 class CryptoRandomPrefetcher {
   constructor(bufSize, valueSize) {
+    if (bufSize % valueSize !== 0) {
+      throw new RangeError('buffer size must be a multiple of value size');
+    }
     this.buf = crypto.randomBytes(bufSize);
     this.pos = 0;
     this.vsz = valueSize;

--- a/test/math.js
+++ b/test/math.js
@@ -19,3 +19,11 @@ metatests.case(
     'common.cryptoRandom': [[result => result >= 0 && result <= 1]],
   }
 );
+
+metatests.test('cryptoPrefetcher with invalid arguments', test => {
+  test.throws(
+    () => common.cryptoPrefetcher(10, 8),
+    new RangeError('buffer size must be a multiple of value size')
+  );
+  test.end();
+});


### PR DESCRIPTION
<!-- Brief summary of the changes: -->
`cryptoPrefetcher()` will now throw when `bufSize` is not a multiple of  `valueSize`.
<!--
Make sure you've completed all of the applicable tasks below.
Change [ ] to [x] for completed items.
-->

- [x] code is properly formatted (`npm run fmt`)
- [x] tests are added/updated
- [x] description of changes is added under the `Unreleased` header in CHANGELOG.md
