### PR TITLE
Fix common.subst() behavior for @.value@ variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - `cryptoPrefetcher()` to throw when `bufSize` is not a multiple of
   `valueSize`.
 
+### Fixed
+
+- `common.subst()` behavior for @.value@ variables.
+
 ## [2.1.0][] - 2019-06-18
 
 ### Added

--- a/lib/strings.js
+++ b/lib/strings.js
@@ -42,7 +42,7 @@ const subst = (tpl, data, dataPath, escapeHtml) => {
 
   const defaultData = getByPath(data, dataPath);
   let result = '';
-  while (end !== -1 && start < tpl.length) {
+  while (end !== -1) {
     result += tpl.substring(start, end);
     start = end + 1;
     end = tpl.indexOf('@', start);
@@ -51,20 +51,13 @@ const subst = (tpl, data, dataPath, escapeHtml) => {
       break;
     }
 
-    let key;
-    let d;
-    if (tpl.charAt(start) !== '.') {
-      key = tpl.slice(start, end);
-      d = data;
-    } else {
-      key = tpl.slice(start + 1, end);
-      d = defaultData;
+    const hasDot = tpl.charAt(start) === '.';
+    const key = tpl.slice(hasDot ? start + 1 : start, end);
+    let value = getByPath(hasDot ? defaultData : data, key);
+    if (hasDot && value === undefined && key === 'value') {
+      value = defaultData;
     }
 
-    let value = getByPath(d, key);
-    if (value === undefined && key === '.value') {
-      value = d;
-    }
     if (value === null) {
       value = '[null]';
     } else if (value === undefined) {
@@ -83,10 +76,9 @@ const subst = (tpl, data, dataPath, escapeHtml) => {
     start = end + 1;
     end = tpl.indexOf('@', start);
   }
-  if (start < tpl.length && end === -1) {
+  if (start < tpl.length) {
     result += tpl.substring(start);
   }
-  end = tpl.indexOf('@', start);
   return result;
 };
 

--- a/test/strings.js
+++ b/test/strings.js
@@ -35,6 +35,7 @@ metatests.case(
         true,
         'Hello, Ali',
       ],
+      ['Hello, @.value@', { name: 'Ali' }, 'name', true, 'Hello, Ali'],
     ],
     'common.section': [
       ['All you need is JavaScript', 'is', ['All you need ', ' JavaScript']],


### PR DESCRIPTION
<!-- Brief summary of the changes: -->
This fixes the `common.subst()` regression that was introduced in https://github.com/metarhia/common/pull/168 related to `@.value@` not working correctly. To achieve the same behavior as before it was required to use `@..value@` instead.

Also, this removes the redundant line at the end of the function.
<!--
Make sure you've completed all of the applicable tasks below.
Change [ ] to [x] for completed items.
-->

- [x] code is properly formatted (`npm run fmt`)
- [x] tests are added/updated
- [x] description of changes is added under the `Unreleased` header in CHANGELOG.md
