### PR TITLE
Add a way to limit the size of MemoryWritable's internal buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ and this project adheres to
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- A way to limit the internal buffer size of `MemoryWritable` stream.
+
 ### Changed
 
 - `cryptoPrefetcher()` to throw when `bufSize` is not a multiple of
   `valueSize`.
+- `MemoryWritable` internal buffer size is now limited to 8 MB by default.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1027,7 +1027,11 @@ files.sort(sortCompareByName);
 
 ### class MemoryWritable extends [Writable][writable]
 
-#### MemoryWritable.prototype.constructor()
+#### MemoryWritable.prototype.constructor(\[sizeLimit\])
+
+- `sizeLimit`: [`<number>`][number]|[`<string>`][string] limit of the internal
+  buffer size specified as number in bytes or as string in format supported by
+  `common.bytesToSize()`. Defaults to 8 MB
 
 #### async MemoryWritable.prototype.getData(\[encoding\])
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,14 +1,24 @@
 'use strict';
 
+const units = require('./units');
+
 const stream = require('stream');
 
 const buffer = Symbol('buffer');
+const storageLeft = Symbol('storageLeft');
+
+const SIZE_LIMIT = 8 * 1000 * 1000; // 8 MB
 
 class MemoryWritable extends stream.Writable {
-  constructor() {
+  // Signature: [sizeLimit]
+  //   sizeLimit <number> | <string> limit of the internal buffer size specified
+  //       as number in bytes or as string in format supported by
+  //       `common.bytesToSize()`. Defaults to 8 MB
+  constructor(sizeLimit = SIZE_LIMIT) {
     super();
 
     this[buffer] = [];
+    this[storageLeft] = units.sizeToBytes(sizeLimit);
     this.finished = false;
     this.once('finish', () => {
       this.finished = true;
@@ -17,6 +27,13 @@ class MemoryWritable extends stream.Writable {
 
   // #private
   _write(chunk, encoding, callback) {
+    this[storageLeft] -= chunk.length;
+    if (this[storageLeft] < 0) {
+      callback(
+        new RangeError(`size limit exceeded by ${-this[storageLeft]} bytes`)
+      );
+      return;
+    }
     this[buffer].push(chunk);
     callback();
   }

--- a/test/stream.js
+++ b/test/stream.js
@@ -38,3 +38,20 @@ metatests.test(
     }
   }
 );
+
+metatests.test('MemoryWritable handles custom sizeLimit', async test => {
+  for (const path of fixturesPaths) {
+    const originalReadable = fs.createReadStream(path);
+    const memoryStream = new common.MemoryWritable(40);
+    originalReadable.pipe(memoryStream);
+    const result = memoryStream.getData();
+    if (path.includes('empty')) {
+      await test.resolves(result, await readFile(path));
+    } else {
+      await test.rejects(
+        result,
+        new RangeError('size limit exceeded by 20 bytes')
+      );
+    }
+  }
+});


### PR DESCRIPTION
<!-- Brief summary of the changes: -->
This will help to avoid excessive memory usage when piping into the `MemoryWritable` stream.
<!--
Make sure you've completed all of the applicable tasks below.
Change [ ] to [x] for completed items.
-->

- [x] code is properly formatted (`npm run fmt`)
- [x] tests are added/updated
- [x] documentation is updated (`npm run doc` to regenerate documentation based on comments)
- [x] description of changes is added under the `Unreleased` header in CHANGELOG.md
