### PR TITLE
Fix common.callerFilepath() working incorrectly on paths with ':'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 ### Fixed
 
 - `common.subst()` behavior for @.value@ variables.
+- `common.callerFilepath()` working incorrectly on paths with colon in them.
 
 ## [2.1.0][] - 2019-06-18
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -34,15 +34,16 @@ const callerFilepath = (depth = 0, stack = null) => {
   } while (frame && nodeModuleMatch.test(frame));
 
   if (frame) {
-    const start = frame.indexOf('(');
-    const end = frame.indexOf(':', start + 1);
-    return frame.substring(start + 1, end);
+    const start = frame.indexOf('(') + 1;
+    const lastColon = frame.lastIndexOf(':');
+    const end = frame.lastIndexOf(':', lastColon - 1);
+    return frame.substring(start, end);
   }
   return '';
 };
 
 const callerFilename = (depth = 0, stack = null) =>
-  basename(callerFilepath(depth + 1, stack) || '');
+  basename(callerFilepath(depth + 1, stack));
 
 module.exports = {
   safe,


### PR DESCRIPTION
<!-- Brief summary of the changes: -->
Also remove redundant logical or expression in `common.callerFilename()`.

There are no tests added since the existing ones already cover this behavior on Windows.
Refs: https://github.com/metarhia/common/pull/304
<!--
Make sure you've completed all of the applicable tasks below.
Change [ ] to [x] for completed items.
-->

- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added under the `Unreleased` header in CHANGELOG.md
