### PR TITLE
Fix callerFilepath()/callerFilename() tests

### DIFF
--- a/test/utilities.js
+++ b/test/utilities.js
@@ -3,8 +3,10 @@
 const metatests = require('metatests');
 const common = require('..');
 
+const path = require('path');
+
 metatests.test('Check called filename/filepath', test => {
-  test.ok(common.callerFilepath().endsWith('test/utilities.js'));
+  test.ok(common.callerFilepath().endsWith(path.join('test', 'utilities.js')));
   test.strictSame(common.callerFilename(), 'utilities.js');
   test.end();
 });
@@ -15,6 +17,8 @@ metatests.test('Check called filename/filepath parent', test => {
 });
 
 function child(test, depth) {
-  test.ok(common.callerFilepath(depth).endsWith('test/utilities.js'));
+  test.ok(
+    common.callerFilepath(depth).endsWith(path.join('test', 'utilities.js'))
+  );
   test.strictSame(common.callerFilename(depth), 'utilities.js');
 }


### PR DESCRIPTION
<!-- Brief summary of the changes: -->
They were failing on OSes where path.sep !== '/'.

<!--
Make sure you've completed all of the applicable tasks below.
Change [ ] to [x] for completed items.
-->

- [x] code is properly formatted (`npm run fmt`)
- [x] tests are added/updated