### PR TITLE
Replace for-loop with recursion

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -85,26 +85,18 @@ const getByPath = (data, dataPath) => {
 //   dataPath - <string>, dot-separated path
 //   value - <any>, new value
 const setByPath = (data, dataPath, value) => {
-  const path = dataPath.split('.');
-  const len = path.length;
-  let obj = data;
-  let i = 0;
-  let next, prop;
-  for (;;) {
+  const props = dataPath.split('.');
+  const iter = (index, obj) => {
     if (typeof obj !== 'object') return false;
-    prop = path[i];
-    if (i === len - 1) {
+    const prop = props[index];
+    if (index >= props.length - 1) {
       obj[prop] = value;
       return true;
     }
-    next = obj[prop];
-    if (next === undefined || next === null) {
-      next = {};
-      obj[prop] = next;
-    }
-    obj = next;
-    i++;
-  }
+    if (obj[prop] === null || obj[prop] === undefined) obj[prop] = {};
+    return iter(index + 1, obj[prop]);
+  };
+  return iter(0, data);
 };
 
 // Delete property by dot-separated path
@@ -112,23 +104,20 @@ const setByPath = (data, dataPath, value) => {
 //   dataPath - <string>, dot-separated path
 // Returns: <boolean>
 const deleteByPath = (data, dataPath) => {
-  const path = dataPath.split('.');
-  let obj = data;
-  const len = path.length;
-  for (let i = 0; i < len; i++) {
-    const prop = path[i];
-    const next = obj[prop];
-    if (i === len - 1) {
+  const props = dataPath.split('.');
+  const iter = (index, obj) => {
+    if (obj === undefined || obj === null) return false;
+    const prop = props[index];
+    if (index >= props.length - 1) {
       if (Object.prototype.hasOwnProperty.call(obj, prop)) {
         delete obj[prop];
         return true;
       }
-    } else {
-      if (next === undefined || next === null) return false;
-      obj = next;
+      return false;
     }
-  }
-  return false;
+    return iter(index + 1, obj[prop]);
+  };
+  return iter(0, data);
 };
 
 // Distinctly merge multiple arrays


### PR DESCRIPTION
I think it's pretty weird to use construction [like this](https://github.com/metarhia/common/blob/8e755c3c793c63dc377a7607b4963c46f379f015/lib/data.js#L93) and [all of those mutable local variables](https://github.com/metarhia/common/blob/8e755c3c793c63dc377a7607b4963c46f379f015/lib/data.js#L90) to keep track a current state. I propose to use recursion. The last seems more natural. I know that JS has some problems with tail rec optimization, but i  I cannot imagine the case when a path will contain many dot-separated properties