### PR TITLE
Better ESM integration with conditional exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to
 - `captureMaxStack()` utility to get maximum available stack trace.
 - Table of contents to documentation.
 - Get random element from array: `sample(array)`.
-- ECMAScript Modules support via importing '@metarhia/common/module'.
+- ECMAScript Modules named exports support.
 - `Iterator#min()`, `Iterator#max()`, and `Iterator#findCompare()` to
   simplify consumption of iterator in common use-cases
   (finding minimum, maximum, or using a custom condition appropriately).

--- a/common.mjs
+++ b/common.mjs
@@ -1,8 +1,5 @@
 // This is an automaticaly generated file. DO NOT MODIFY MANUALLY.
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
-const common = require('./common.js');
+import common from './common.js';
 
 export default common;
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,13 @@
   },
   "main": "common.js",
   "exports": {
-    ".": "./common.js",
-    "./module": "./common.mjs"
+    ".": {
+      "require": "./common.js",
+      "import": "./common.mjs"
+    },
+    "./lib/": {
+      "require": "./lib/"
+    }
   },
   "browser": {
     "common.js": "./dist/common.js",

--- a/tools/esmodules-export-gen.js
+++ b/tools/esmodules-export-gen.js
@@ -11,10 +11,7 @@ const COMMON_MJS_FILEPATH = './common.mjs';
 
 const header = indexPath =>
   `// This is an automaticaly generated file. DO NOT MODIFY MANUALLY.
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
-const common = require('./${indexPath}');
+import common from './${indexPath}';
 
 export default common;
 


### PR DESCRIPTION
Since Conditional exports are not experimental anymore this will allow
to use @metarhia/common as follows:

```js
import common from '@metarhia/common'
```

Without the need for additional `/module` suffix.

<!-- Brief summary of the changes: -->

<!--
Make sure you've completed all of the applicable tasks below.
Change [ ] to [x] for completed items.
-->

- [x] code is properly formatted (`npm run fmt`)
- [x] tests are added/updated
- [x] documentation is updated (`npm run doc` to regenerate documentation based on comments)
- [x] description of changes is added under the `Unreleased` header in CHANGELOG.md


Just read through the docs and found out it's not experimental anymore and since we haven't released the current version this would IMO be better.