### PR TITLE
Allow to wrap iterator with Iterator

### DIFF
--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -11,7 +11,9 @@ const toIterator = base => {
 
 class Iterator {
   constructor(base) {
-    this.base = toIterator(base);
+    if (typeof base.next !== 'function')
+      throw new TypeError('Base is not Iterable');
+    this.base = base;
   }
 
   [Symbol.iterator]() {
@@ -490,7 +492,7 @@ class SkipWhileIterator extends Iterator {
   }
 }
 
-const iter = base => new Iterator(base);
+const iter = base => new Iterator(toIterator(base));
 
 module.exports = {
   Iterator,

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -12,6 +12,11 @@ metatests.test('new Iterator() on non Iterable', test => {
   test.end();
 });
 
+metatests.testSync('new Iterator() on Iterator', test => {
+  const it = array[Symbol.iterator]();
+  test.strictSame(new Iterator(it).toArray(), array);
+});
+
 metatests.test('iter returns an Iterator', test => {
   const iterator = iter(array);
   test.assert(iterator instanceof Iterator);


### PR DESCRIPTION
Previously only objects with Symbol.iterator property were supported.
This makes our Iterator only check for .next function on `base`
and only perform `toIterator` if called with `iter` function.

This is a BREAKING CHANGE.

<!-- Brief summary of the changes: -->

<!--
Make sure you've completed all of the applicable tasks below.
Change [ ] to [x] for completed items.
-->

- [x] code is properly formatted (`npm run fmt`)
- [x] tests are added/updated
- [ ] documentation is updated (`npm run doc` to regenerate documentation based on comments)
- [ ] description of changes is added under the `Unreleased` header in CHANGELOG.md

Will update docs and changelog when we reach consensus on this as there are multiple options here.