### PR TITLE
Implement iterator#min, iterator#max, iterator#findCompare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to
 - Table of contents to documentation.
 - Get random element from array: `sample(array)`.
 - ECMAScript Modules support via importing '@metarhia/common/module'.
+- `Iterator#min()`, `Iterator#max()`, and `Iterator#findCompare()` to
+  simplify consumption of iterator in common use-cases
+  (finding minimum, maximum, or using a custom condition appropriately).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -151,12 +151,15 @@ $ npm install @metarhia/common
   - [Iterator.prototype.filter](#iteratorprototypefilterpredicate-thisarg)
   - [Iterator.prototype.filterMap](#iteratorprototypefiltermapmapper-thisarg-filtervalue)
   - [Iterator.prototype.find](#iteratorprototypefindpredicate-thisarg)
+  - [Iterator.prototype.findCompare](#iteratorprototypefindcomparecomparator-accessor-thisarg)
   - [Iterator.prototype.flat](#iteratorprototypeflatdepth--1)
   - [Iterator.prototype.flatMap](#iteratorprototypeflatmapmapper-thisarg)
   - [Iterator.prototype.forEach](#iteratorprototypeforeachfn-thisarg)
   - [Iterator.prototype.includes](#iteratorprototypeincludeselement)
   - [Iterator.prototype.join](#iteratorprototypejoinsep----prefix---suffix--)
   - [Iterator.prototype.map](#iteratorprototypemapmapper-thisarg)
+  - [Iterator.prototype.max](#iteratorprototypemaxaccessor-thisarg)
+  - [Iterator.prototype.min](#iteratorprototypeminaccessor-thisarg)
   - [Iterator.prototype.next](#iteratorprototypenext)
   - [Iterator.prototype.reduce](#iteratorprototypereducereducer-initialvalue)
   - [Iterator.prototype.skip](#iteratorprototypeskipamount)
@@ -1120,6 +1123,27 @@ This iterator will call `mapper` on each element and if mapper returns NOT
 
 #### Iterator.prototype.find(predicate, thisArg)
 
+#### Iterator.prototype.findCompare(comparator\[, accessor\[, thisArg\]\])
+
+- `comparator`: [`<Function>`][function] returns `true` if new value should be
+  accepted
+  - `currValue`: `<any>` current value, starts with undefined
+  - `nextValue`: `<any>` next value
+  - _Returns:_ [`<boolean>`][boolean] `true` if next value should be accepted
+- `accessor`: [`<Function>`][function] gets value to compare by, current
+  iterator value is used by default
+  - `value`: `<any>` current iterator value
+  - _Returns:_ `<any>` value to compare by
+- `thisArg`: `<any>` value to be used as `this` when calling `accessor` and
+  `comparator`
+
+_Returns:_ last iterator value where `comparator` returned `true`,
+[`<undefined>`][undefined] by default
+
+Find value in this iterator by comparing every value with
+
+the found one using `comparator`
+
 #### Iterator.prototype.flat(depth = 1)
 
 #### Iterator.prototype.flatMap(mapper, thisArg)
@@ -1131,6 +1155,32 @@ This iterator will call `mapper` on each element and if mapper returns NOT
 #### Iterator.prototype.join(sep = ', ', prefix = '', suffix = '')
 
 #### Iterator.prototype.map(mapper, thisArg)
+
+#### Iterator.prototype.max(\[accessor\[, thisArg\]\])
+
+- `accessor`: [`<Function>`][function] gets value to compare by, current
+  iterator value is used by default
+  - `value`: `<any>` current iterator value
+  - _Returns:_ `<any>` value to compare by
+- `thisArg`: `<any>` value to be used as `this` when calling `accessor`
+
+_Returns:_ element with maximum value or [`<undefined>`][undefined] if iterator
+is empty
+
+Find the maximum value in this iterator
+
+#### Iterator.prototype.min(\[accessor\[, thisArg\]\])
+
+- `accessor`: [`<Function>`][function] gets value to compare by, current
+  iterator value is used by default
+  - `value`: `<any>` current iterator value
+  - _Returns:_ `<any>` value to compare by
+- `thisArg`: `<any>` value to be used as `this` when calling `accessor`
+
+_Returns:_ element with minimum value or [`<undefined>`][undefined] if iterator
+is empty
+
+Find the minimum value in this iterator
 
 #### Iterator.prototype.next()
 
@@ -1751,6 +1801,7 @@ See github for full [contributors list](https://github.com/metarhia/common/graph
 [typeerror]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError
 [boolean]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type
 [null]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Null_type
+[undefined]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Undefined_type
 [number]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type
 [string]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type
 [object.fromentries()]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -199,6 +199,66 @@ class Iterator {
     return result + suffix;
   }
 
+  // Find value in this iterator by comparing every value with
+  // the found one using `comparator`
+  // Signature: comparator[, accessor[, thisArg]]
+  //   comparator <Function> returns `true` if new value should be accepted
+  //     currValue <any> current value, starts with undefined
+  //     nextValue <any> next value
+  //     Returns: <boolean> `true` if next value should be accepted
+  //   accessor <Function> gets value to compare by, current iterator value
+  //       is used by default
+  //     value <any> current iterator value
+  //     Returns: <any> value to compare by
+  //   thisArg <any> value to be used as `this` when calling `accessor` and
+  //       `comparator`
+  // Returns: last iterator value where `comparator` returned `true`,
+  //     <undefined> by default
+  findCompare(comparator, accessor, thisArg) {
+    let res = undefined;
+    let resCompareBy = undefined;
+    for (const value of this) {
+      const compareBy = accessor ? accessor.call(thisArg, value) : value;
+      if (comparator.call(thisArg, resCompareBy, compareBy)) {
+        resCompareBy = compareBy;
+        res = value;
+      }
+    }
+    return res;
+  }
+
+  // Find the maximum value in this iterator
+  // Signature: [accessor[, thisArg]]
+  //   accessor <Function> gets value to compare by, current iterator value
+  //       is used by default
+  //     value <any> current iterator value
+  //     Returns: <any> value to compare by
+  //   thisArg <any> value to be used as `this` when calling `accessor`
+  // Returns: element with maximum value or <undefined> if iterator is empty
+  max(accessor, thisArg) {
+    return this.findCompare(
+      (curr, next) => curr === undefined || next > curr,
+      accessor,
+      thisArg
+    );
+  }
+
+  // Find the minimum value in this iterator
+  // Signature: [accessor[, thisArg]]
+  //   accessor <Function> gets value to compare by, current iterator value
+  //       is used by default
+  //     value <any> current iterator value
+  //     Returns: <any> value to compare by
+  //   thisArg <any> value to be used as `this` when calling `accessor`
+  // Returns: element with minimum value or <undefined> if iterator is empty
+  min(accessor, thisArg) {
+    return this.findCompare(
+      (curr, next) => curr === undefined || next < curr,
+      accessor,
+      thisArg
+    );
+  }
+
   // Call a function with `this`. Will be equivalent to calling `fn(it)`.
   //   fn <Function>
   //     this <Iterator>

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -662,6 +662,111 @@ metatests.testSync('Iterator.chainApply on string', test => {
   test.strictSame(actual, 'h e l l o');
 });
 
+metatests.testSync('Iterator.max no values', test => {
+  const actual = iter([]).max();
+  test.strictSame(actual, undefined);
+});
+
+metatests.testSync('Iterator.max simple', test => {
+  const actual = iter([1, 2, 3, 4, 5]).max();
+  test.strictSame(actual, 5);
+});
+
+metatests.testSync('Iterator.max accessor', test => {
+  const arr = [{ val: 5 }, { val: 4 }, { val: 3 }, { val: 9 }, { val: 4 }];
+  const actual = iter(arr).max(v => v.val);
+  test.strictSame(actual, arr[3]);
+});
+
+metatests.testSync('Iterator.max accessor this', test => {
+  class Arr extends Array {
+    constructor(offset, val) {
+      super(...val);
+      this.offset = offset;
+    }
+
+    getVal(val) {
+      return this.offset * val;
+    }
+  }
+  const arr = new Arr(-1, [5, 4, 3, 2, 1]);
+  const actual = iter(arr).max(arr.getVal, arr);
+  test.strictSame(actual, 1);
+});
+
+metatests.testSync('Iterator.min no values', test => {
+  const actual = iter([]).min();
+  test.strictSame(actual, undefined);
+});
+
+metatests.testSync('Iterator.min simple', test => {
+  const actual = iter([1, 2, 3, 4, 5]).min();
+  test.strictSame(actual, 1);
+});
+
+metatests.testSync('Iterator.min accessor', test => {
+  const arr = [{ val: 5 }, { val: 4 }, { val: 3 }, { val: 9 }, { val: 4 }];
+  const actual = iter(arr).min(v => v.val);
+  test.strictSame(actual, arr[2]);
+});
+
+metatests.testSync('Iterator.min accessor this', test => {
+  class Arr extends Array {
+    constructor(offset, val) {
+      super(...val);
+      this.offset = offset;
+    }
+
+    getVal(val) {
+      return this.offset * val;
+    }
+  }
+  const arr = new Arr(-1, [1, 2, 3, 4, 5]);
+  const actual = iter(arr).min(arr.getVal, arr);
+  test.strictSame(actual, 5);
+});
+
+metatests.testSync('Iterator.findCompare no values', test => {
+  const actual = iter([]).findCompare();
+  test.strictSame(actual, undefined);
+});
+
+metatests.testSync('Iterator.findCompare simple', test => {
+  const actual = iter([1, 2, 3, 4, 5]).findCompare(
+    (curr, next) => curr === undefined || next < 3
+  );
+  test.strictSame(actual, 2);
+});
+
+metatests.testSync('Iterator.findCompare accessor', test => {
+  const arr = [{ val: 5 }, { val: 4 }, { val: 3 }, { val: 9 }, { val: 4 }];
+  const actual = iter(arr).findCompare(
+    (curr, next) => curr === undefined || Math.abs(curr - next) < 2,
+    v => v.val
+  );
+  test.strictSame(actual, arr[4]);
+});
+
+metatests.testSync('Iterator.findCompare accessor this', test => {
+  class Arr extends Array {
+    constructor(offset, val) {
+      super(...val);
+      this.offset = offset;
+    }
+
+    getVal(val) {
+      return this.offset * val;
+    }
+  }
+  const arr = new Arr(-1, [1, 2, 3, 4, 5]);
+  const actual = iter(arr).findCompare(
+    (curr, next) => curr === undefined || next < 0,
+    arr.getVal,
+    arr
+  );
+  test.strictSame(actual, 5);
+});
+
 metatests.testSync('iterEntries must iterate over object entries', test => {
   const source = { a: 13, b: 42, c: 'hello' };
   test.strictSame(iterEntries(source).toArray(), Object.entries(source));


### PR DESCRIPTION
This will simplify the consumption of Iterator in common use-cases.
Allows of searching value based on comparable condition with findCompare
and adds simple wrappers around findCompare to implement min and max
functions.

<!-- Brief summary of the changes: -->

<!--
Make sure you've completed all of the applicable tasks below.
Change [ ] to [x] for completed items.
-->

- [x] code is properly formatted (`npm run fmt`)
- [x] tests are added/updated
- [x] documentation is updated (`npm run doc` to regenerate documentation based on comments)
- [x] description of changes is added under the `Unreleased` header in CHANGELOG.md
