### PR TITLE
Version 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased][unreleased]
 
+## [2.2.0][] - 2020-07-10
+
 ### Added
 
 - A way to limit the internal buffer size of `MemoryWritable` stream.
@@ -195,7 +197,8 @@ and this project adheres to
 
 - The first stable version of the `@metarhia/common` package.
 
-[unreleased]: https://github.com/metarhia/common/compare/v2.1.0...HEAD
+[unreleased]: https://github.com/metarhia/common/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/metarhia/common/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/metarhia/common/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/metarhia/common/compare/v1.5.0...v2.0.0
 [1.5.0]: https://github.com/metarhia/common/compare/v1.4.2...v1.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@metarhia/common",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metarhia/common",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": "Timur Shemsedinov <timur.shemsedinov@gmail.com>",
   "description": "Metarhia Common Library",
   "license": "MIT",


### PR DESCRIPTION
## Release summary:

Applied fixes and improvements to the API, added multiple utility methods to
the Iterator API and several utility functions, added table of contents to the
documentation.

## Changelog:

### Added

- A way to limit the internal buffer size of `MemoryWritable` stream.
- `common.mkdirpPromise()` function.
- `Iterator#apply()` and `Iterator#chainApply()` to improve iterator
  interaction with chained calls.
- `captureMaxStack()` utility to get maximum available stack trace.
- Table of contents to documentation.
- Get random element from array: `sample(array)`.
- ECMAScript Modules named exports support.
- `Iterator#min()`, `Iterator#max()`, and `Iterator#findCompare()` to
  simplify consumption of iterator in common use-cases
  (finding minimum, maximum, or using a custom condition appropriately).
- `Iterator#partition()` to allow splitting iterator values into
  multiple arrays.
- `Iterator.zip()` - static method for zipping iterators.
- `Iterator#groupBy()` to group iterator value into Map by
  specific keys.

### Changed

- `cryptoPrefetcher()` to throw when `bufSize` is not a multiple of
  `valueSize`.
- `MemoryWritable` internal buffer size is now limited to 8 MB by default.
- Signature of `callerFilepath()` to allow passing `RegExp` as depth to be used
  for filtering of stack frames.
- Return value of `cryptoPrefetcher()` now implements the Iterable interface.

### Fixed

- `common.subst()` behavior for @.value@ variables.
- `common.callerFilepath()` working incorrectly on paths with colon in them.