### PR TITLE
Implement Iterator.indices to get array indexes as range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- `Iterator.indices()` to simplify iterating over indices of an array.
+
 ## [2.2.0][] - 2020-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1057,7 +1057,7 @@ Convert file path to id
 
 _Returns:_ `<Iterator>`
 
-Create iterator over indices of an array.
+Create iterator over indices of an array
 
 #### Iterator.range(start, stop\[, step\])
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ $ npm install @metarhia/common
   - [Int64.prototype.toUint32](#int64prototypetouint32)
   - [Int64.prototype.xor](#int64prototypexorb)
 - [Iterator](#class-iterator)
+  - [Iterator.indices](#iteratorindicesarr)
   - [Iterator.range](#iteratorrangestart-stop-step)
   - [Iterator.zip](#iteratorzipiterators)
   - [Iterator.prototype.constructor](#iteratorprototypeconstructorbase)
@@ -1049,6 +1050,14 @@ Convert file path to id
 #### Int64.prototype.xor(b)
 
 ### class Iterator
+
+#### Iterator.indices(arr)
+
+- `arr`: [`<Array>`][array] array-like object to create indices from
+
+_Returns:_ `<Iterator>`
+
+Create iterator over indices of an array.
 
 #### Iterator.range(start, stop\[, step\])
 

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -347,7 +347,7 @@ class Iterator {
     return new Iterator(rangeGenerator(start, stop, step));
   }
 
-  // Create iterator over indices of an array.
+  // Create iterator over indices of an array
   //   arr <Array> array-like object to create indices from
   // Returns: <Iterator>
   static indices(arr) {

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -346,6 +346,13 @@ class Iterator {
   static range(start, stop, step) {
     return new Iterator(rangeGenerator(start, stop, step));
   }
+
+  // Create iterator over indices of an array.
+  //   arr <Array> array-like object to create indices from
+  // Returns: <Iterator>
+  static indices(arr) {
+    return Iterator.range(0, arr.length);
+  }
 }
 
 Object.defineProperty(Iterator.prototype, Symbol.toStringTag, {

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -903,6 +903,21 @@ metatests.testSync('Iterator.groupBy thisArg', test => {
   );
 });
 
+metatests.testSync('Iterator.indices on empty array', test => {
+  const actual = Iterator.indices([]).toArray();
+  test.strictSame(actual, []);
+});
+
+metatests.testSync('Iterator.indices on array', test => {
+  const actual = Iterator.indices([1, 2, 3]).toArray();
+  test.strictSame(actual, [0, 1, 2]);
+});
+
+metatests.testSync('Iterator.indices on object with length', test => {
+  const actual = Iterator.indices({ length: 4 }).toArray();
+  test.strictSame(actual, [0, 1, 2, 3]);
+});
+
 metatests.testSync('iterEntries must iterate over object entries', test => {
   const source = { a: 13, b: 42, c: 'hello' };
   test.strictSame(iterEntries(source).toArray(), Object.entries(source));


### PR DESCRIPTION
This will allow to simplify `range` generation for array indexing.

Refs: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/indices.html

<!-- Brief summary of the changes: -->

<!--
Make sure you've completed all of the applicable tasks below.
Change [ ] to [x] for completed items.
-->

- [x] code is properly formatted (`npm run fmt`)
- [x] tests are added/updated
- [x] documentation is updated (`npm run doc` to regenerate documentation based on comments)
- [x] description of changes is added under the `Unreleased` header in CHANGELOG.md
