### PR TITLE
Implement privatize, private fields on prototypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ $ npm install @metarhia/common
 - [parseHost](#parsehosthost)
 - [override](#overrideobj-fn)
 - [mixin](#mixintarget-source)
+- [privatize](#privatizeinstance)
 - [Pool](#class-pool)
   - [Pool.prototype.constructor](#poolprototypeconstructorfactory--null)
   - [Pool.prototype.get](#poolprototypeget)
@@ -1333,6 +1334,20 @@ Previous function will be accessible by obj.fnName.inherited
 - `source`: [`<Object>`][object] source methods
 
 Mixin for ES6 classes without overriding existing methods
+
+### privatize(instance)
+
+- `instance`: [`<Object>`][object] source instance
+
+_Returns:_ [`<Object>`][object] - destination instance
+
+Convert instance with public fields to instance with private fields
+
+_Example:_
+
+```js
+common.privatize({ private: 5, f() { return this.private; } });
+```
 
 ### class Pool
 

--- a/common.mjs
+++ b/common.mjs
@@ -90,6 +90,7 @@ export const localIPs = common.localIPs;
 export const parseHost = common.parseHost;
 export const override = common.override;
 export const mixin = common.mixin;
+export const privatize = common.privatize;
 export const Pool = common.Pool;
 export const sortComparePriority = common.sortComparePriority;
 export const sortCompareDirectories = common.sortCompareDirectories;

--- a/lib/oop.js
+++ b/lib/oop.js
@@ -23,7 +23,29 @@ const mixin = (target, source) => {
   Object.assign(target, mix);
 };
 
+// Convert instance with public fields to instance with private fields
+//   instance - <Object>, source instance
+// Returns: <Object> - destination instance
+//
+// Example: common.privatize({ private: 5, f() { return this.private; } });
+const privatize = instance => {
+  const iface = {};
+  const fields = Object.keys(instance);
+  for (const fieldName of fields) {
+    const field = instance[fieldName];
+    if (fieldName === fieldName.toUpperCase()) {
+      iface[fieldName] = field;
+    } else if (typeof field === 'function') {
+      const bindedMethod = field.bind(instance);
+      iface[fieldName] = bindedMethod;
+      instance[fieldName] = bindedMethod;
+    }
+  }
+  return iface;
+};
+
 module.exports = {
   override,
   mixin,
+  privatize,
 };

--- a/test/oop.js
+++ b/test/oop.js
@@ -62,3 +62,18 @@ metatests.test('multiple inheritance with mixin', test => {
   test.strictSame(obj.property5, 'from Child.method3');
   test.end();
 });
+
+metatests.test('privatize', test => {
+  const source = {
+    CONSTANT: 'constant value',
+    field: 'field value',
+    method() {
+      return [this.CONSTANT, this.field];
+    },
+  };
+  const destination = common.privatize(source);
+  test.strictSame(destination.CONSTANT, 'constant value');
+  test.strictSame(destination.field, undefined);
+  test.strictSame(destination.method(), ['constant value', 'field value']);
+  test.end();
+});


### PR DESCRIPTION
Function moved from impress and needed for 
- [x] code is properly formatted (`npm run fmt`)
- [x] tests are added/updated
- [x] documentation is updated (`npm run doc` to regenerate documentation based on comments)
- [ ] description of changes is added under the `Unreleased` header in CHANGELOG.md
